### PR TITLE
remove the startup probe to speed up the cold start time

### DIFF
--- a/kustomize/cloudrun.yaml
+++ b/kustomize/cloudrun.yaml
@@ -38,12 +38,14 @@ spec:
           limits:
             cpu: 1000m
             memory: 512Mi
-        startupProbe:
-          timeoutSeconds: 10
-          periodSeconds: 10
-          failureThreshold: 10
-          httpGet:
-            path: /healthcheck
+        # comenting this out for now because the startup latency is 1.12s
+        # this displays a 1sec imposed delay from the first failed healthcheck and the retry
+        #startupProbe:
+        #  timeoutSeconds: 1
+        #  periodSeconds: 1
+        #  failureThreshold: 1
+        #  httpGet:
+        #    path: /healthcheck
   traffic:
   - percent: 100
     latestRevision: true


### PR DESCRIPTION
changing period timeout to 1sec moved the cold start to 1.12 sec, now it's bottlenecked by the period timeout of 1sec

<img width="547" alt="image" src="https://github.com/user-attachments/assets/7b51ac01-cc17-4cae-877c-1119ef01d246">

<img width="547" alt="image" src="https://github.com/user-attachments/assets/81a6138b-f09a-4133-a590-0e7904e1680c">

metrics fell to .41sec with this change, which I'm not sure is possible using a startup probe if the first request is expected to fail (given it fires instantly or with a minimum delay of 1sec)
