### PR TITLE
add a path from the root domain to the functioning part of the app.

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -188,6 +188,8 @@ func main() {
 	mux.HandleFunc("/api/chatFeedback", chatFeedbackHandler)
 	mux.HandleFunc("/api/message/verify", messageHandler(MESSAGE_FEEDBACK_VERIFICATION))
 	mux.HandleFunc("/api/message/improve", messageHandler(MESSAGE_FEEDBACK_IMPROVEMENT))
+	// Send requests to the root domain to something visible
+	mux.HandleFunc("/", http.RedirectHandler("/static", http.StatusFound).ServeHTTP)
 
 	logger.Infof("Starting server on port %v", port)
 	err = http.ListenAndServe(fmt.Sprintf(":%v", port), mux)


### PR DESCRIPTION
```
$ curl -i https://local.chatparser.xyz/
HTTP/2 302
server: nginx/1.27.0
date: Fri, 19 Jul 2024 22:40:45 GMT
content-type: text/html; charset=utf-8
content-length: 30
location: /static

<a href="/static">Found</a>.
```