### PR TITLE
add error handling for a new error on GCS

### DIFF
--- a/src/storage.go
+++ b/src/storage.go
@@ -97,6 +97,9 @@ func write(userId string, objectType ObjectType, text string) (err error) {
 
 	// 3. write object
 	client, err := getStorageClient()
+	if err != nil {
+		return err
+	}
 	storageObj := client.Bucket(bucket).Object(storagePath)
 	w := storageObj.NewWriter(ctx)
 	if _, err := w.Write([]byte(compressed.Bytes())); err != nil {


### PR DESCRIPTION
with an error, we can still proceed 🙌 
```
chatparser-prod-1  | 2024-07-19T22:42:01.144Z	ERROR	app/main.go:140	write error
chatparser-prod-1  | main.main.messageHandler.func2
chatparser-prod-1  | 	/app/main.go:140
chatparser-prod-1  | net/http.HandlerFunc.ServeHTTP
chatparser-prod-1  | 	/usr/local/go/src/net/http/server.go:2171
chatparser-prod-1  | net/http.(*ServeMux).ServeHTTP
chatparser-prod-1  | 	/usr/local/go/src/net/http/server.go:2688
chatparser-prod-1  | net/http.serverHandler.ServeHTTP
chatparser-prod-1  | 	/usr/local/go/src/net/http/server.go:3142
chatparser-prod-1  | net/http.(*conn).serve
chatparser-prod-1  | 	/usr/local/go/src/net/http/server.go:2044
chatparser-prod-1  | 2024-07-19T22:42:01.144Z	ERROR	app/main.go:141	dialing: google: could not find default credentials. See https://cloud.google.com/docs/authentication/external/set-up-adc for more information
chatparser-prod-1  | main.main.messageHandler.func2
chatparser-prod-1  | 	/app/main.go:141
chatparser-prod-1  | net/http.HandlerFunc.ServeHTTP
chatparser-prod-1  | 	/usr/local/go/src/net/http/server.go:2171
chatparser-prod-1  | net/http.(*ServeMux).ServeHTTP
chatparser-prod-1  | 	/usr/local/go/src/net/http/server.go:2688
chatparser-prod-1  | net/http.serverHandler.ServeHTTP
chatparser-prod-1  | 	/usr/local/go/src/net/http/server.go:3142
chatparser-prod-1  | net/http.(*conn).serve
chatparser-prod-1  | 	/usr/local/go/src/net/http/server.go:2044
nginx-1            | 192.168.65.1 - - [19/Jul/2024:22:42:01 +0000] "POST /api/message/verify HTTP/2.0" 200 462 "https://local.chatparser.xyz/static/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36" "-"
```