### PR TITLE
Prevent dictionary page from "submitting" on first character press.

### DIFF
--- a/src/web/src/components/DictInputForm.tsx
+++ b/src/web/src/components/DictInputForm.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Button from './Button';
 import TextArea from './TextArea';
 import styles from './styles/DictInputForm.module.css';
@@ -15,14 +15,18 @@ const TextInputForm: React.FC = () => {
 		setResponse,
 	} = useChatContext();
 
+	const [hasLoaded, setHasLoaded] = useState<boolean>(false);
 	React.useEffect(() => {
 		const initialValue = getInputQueryParamValue()
 		setText(initialValue);
 	}, [])
 	React.useEffect(() => {
-		// checking !previousText should ensure this only runs once
-		if (text && !previousText) {
+		// checking these should ensure this only runs once
+		if (text && !previousText && !hasLoaded) {
 			handleSendMessage();
+		} else {
+			// Set hasLoaded otherwise it will run on the first character submit
+			setHasLoaded(true);
 		}
 	}, [text]) // we need to wait for the state to set, or  we face a race condition
 


### PR DESCRIPTION
* fixes #43 
* add state to `DictInputForm` to account for first loading
![nosubmit](https://github.com/user-attachments/assets/4beca6c3-15f1-4464-b4f4-0b18568a6a39)
