### PR TITLE
Update string constants as they relate to API hooks

### DIFF
--- a/src/web/src/constants.ts
+++ b/src/web/src/constants.ts
@@ -1,15 +1,10 @@
 // API Related
-export const API_ENDPOINTS = {
-	MESSAGE: (mode: string) => `/api/message/${mode}`,
-	AI_REQUEST_STREAM: '/api/ai-response/stream',
-};
-
 export const HTTP_METHODS = {
 	POST: 'POST',
 };
 
-export const CONTENT_TYPES = {
-	TEXT_PLAIN: 'text/plain',
+export const CONTENT_TYPE_HEADER = {
+	TEXT: {'Content-Type': 'text/plain'},
 };
 
 // Error Handling

--- a/src/web/src/hooks/useMessageApi.ts
+++ b/src/web/src/hooks/useMessageApi.ts
@@ -1,7 +1,6 @@
 import {MessageApiResult, Mode} from '../types';
 import {
-	API_ENDPOINTS,
-	CONTENT_TYPES,
+	CONTENT_TYPE_HEADER,
 	ERROR_MESSAGES,
 	HTTP_METHODS,
 	SUBMIT_ERROR,
@@ -13,10 +12,10 @@ export const useMessageApi = () => {
 		mode: Mode,
 	): Promise<MessageApiResult> => {
 		try {
-			const response = await fetch(API_ENDPOINTS.MESSAGE(mode), {
+			const response = await fetch(`/api/message/${mode}`, {
 				method: HTTP_METHODS.POST,
 				headers: {
-					'Content-Type': CONTENT_TYPES.TEXT_PLAIN,
+					...CONTENT_TYPE_HEADER.TEXT
 				},
 				body: text,
 			});
@@ -42,10 +41,10 @@ export const useMessageApi = () => {
 		text: string,
 	): AsyncGenerator<string, void, unknown> {
 		try {
-			const response = await fetch(API_ENDPOINTS.AI_REQUEST_STREAM, {
+			const response = await fetch('/api/ai-response/stream', {
 				method: HTTP_METHODS.POST,
 				headers: {
-					'Content-Type': CONTENT_TYPES.TEXT_PLAIN,
+					...CONTENT_TYPE_HEADER.TEXT
 				},
 				body: text,
 			});


### PR DESCRIPTION
The constants file is great and brings a lot of sanity to strings in the application, but as it relates to the API hooks I think there's an opportunity to simplify a bit more, through two updates

**API HEADERS**
utilize an entire header object for the content type header, i.e.
```
headers: {
  ...CONTENT_TYPE_HEADER.TEXT
}
```
this allows us to avoid a line with a hard-coded string AND a constant defined elsewhere, i.e.
```
headers: {
  'Content-Type': CONTENT_TYPE.TEXT_PLAIN,
}
```

**API ENDPOINTS**
move API endpoint names into the methods that call them, i.e.
```
	const aiRequestStream = async function* (
		text: string,
	): AsyncGenerator<string, void, unknown> {
		try {
			const response = await fetch('/api/ai-response/stream', {
```
this allows us to keep all the relevant implementation details together:
- what API endpoint is being called
- how the request is being formed (post data)
- how the response is being handled

when split into a constants file, it requires looking at/updating two different files for changes to APIs.

NOTE: if API endpoints are utilized in more places, this could result in more duplication, but the structure of the API as it exists suggests we'll have one method for each API endpoint.
