### PR TITLE
Set the kaniko cache at 30 days

### DIFF
--- a/cloudbuild/build.yaml
+++ b/cloudbuild/build.yaml
@@ -4,7 +4,7 @@ steps:
   - --destination=us-central1-docker.pkg.dev/$PROJECT_ID/docker/chatparser:$SHORT_SHA
   - --context=src/
   - --cache=true
-  - --cache-ttl=30d
+  - --cache-ttl 30d
 
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/cloudbuild/build.yaml
+++ b/cloudbuild/build.yaml
@@ -4,7 +4,7 @@ steps:
   - --destination=us-central1-docker.pkg.dev/$PROJECT_ID/docker/chatparser:$SHORT_SHA
   - --context=src/
   - --cache=true
-  - --cache-ttl=6h
+  - --cache-ttl=30d
 
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/cloudbuild/build.yaml
+++ b/cloudbuild/build.yaml
@@ -4,7 +4,7 @@ steps:
   - --destination=us-central1-docker.pkg.dev/$PROJECT_ID/docker/chatparser:$SHORT_SHA
   - --context=src/
   - --cache=true
-  - --cache-ttl 720h
+  - --cache-ttl=720h
 
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/cloudbuild/build.yaml
+++ b/cloudbuild/build.yaml
@@ -4,7 +4,7 @@ steps:
   - --destination=us-central1-docker.pkg.dev/$PROJECT_ID/docker/chatparser:$SHORT_SHA
   - --context=src/
   - --cache=true
-  - --cache-ttl 30d
+  - --cache-ttl 720h
 
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -3,8 +3,7 @@ FROM node:22-alpine3.18 AS staticbuilder
 # https://github.com/docker-library/official-images/issues/16830
 RUN corepack enable && yarn set version berry
 WORKDIR /srv/app
-COPY web/package.json ./
-COPY web/yarn.lock ./
+COPY web/package.json web/yarn.lock ./
 RUN yarn install
 COPY web /srv/app
 RUN yarn run build


### PR DESCRIPTION
extend the build cache validity time so we get caches on more dependabot builds (weekly)